### PR TITLE
Fix pickling bug when n_workers > 1 

### DIFF
--- a/proteinshake/representations/dgl_data.py
+++ b/proteinshake/representations/dgl_data.py
@@ -1,0 +1,30 @@
+import os
+
+import dgl
+import torch
+from dgl.data import DGLDataset
+from dgl import save_graphs, load_graphs
+
+class Dataset(DGLDataset):
+    def __init__(self, path, proteins, info):
+        if os.path.exists(path):
+            self.proteins = load_graphs(path)
+        else:
+            self.proteins = [graph2dgl(p, info=info) for p,info in zip(proteins,info)]
+            save_graphs(path, self.proteins)
+    def __getitem__(self, i):
+            return self.proteins[i]
+    def __len__(self):
+            return len(self.proteins)
+
+
+def graph2dgl(graph, info={}):
+    g = dgl.from_scipy(graph[1])
+    for key,value in info.items():
+        if type(value) == list and len(value) == len(info['sequence']):
+            try:
+                g.ndata[key] = torch.tensor(value)
+            except:
+                pass
+    return g
+

--- a/proteinshake/representations/graph.py
+++ b/proteinshake/representations/graph.py
@@ -92,34 +92,11 @@ class GraphDataset():
                        pre_filter=pre_filter)
 
     def dgl(self):
-        raise NotImplementedError
+        from .dgl_data import Dataset
 
-    def dgl(self):
-        from dgl.data import DGLDataset
-        from dgl import save_graphs, load_graphs
-        import dgl
-        import torch
-        def graph2dgl(graph, info={}):
-            g = dgl.from_scipy(graph[1])
-            for key,value in info.items():
-                if type(value) == list and len(value) == len(info['sequence']):
-                    try:
-                        g.ndata[key] = torch.tensor(value)
-                    except:
-                        pass
-            return g
-        class Dataset(DGLDataset):
-            def __init__(self, path, proteins, info):
-                if os.path.exists(path):
-                    self.proteins = load_graphs(path)
-                else:
-                    self.proteins = [graph2dgl(p, info=info) for p,info in zip(proteins,info)]
-                    save_graphs(path, self.proteins)
-            def __getitem__(self, i):
-                    return self.proteins[i]
-            def __len__(self):
-                    return len(self.proteins)
-        ds = Dataset(f'{self.root}/processed/graph/{self.name}.dgl.pkl',  self.proteins, self.info)
+        ds = Dataset(f'{self.root}/processed/graph/{self.name}.dgl.pkl',
+                     self.proteins,
+                     self.info)
         return ds
 
         @checkpoint('{root}/processed/graph/{name}.nx.pkl')

--- a/proteinshake/representations/graph.py
+++ b/proteinshake/representations/graph.py
@@ -3,7 +3,7 @@ from sklearn.neighbors import kneighbors_graph, radius_neighbors_graph
 from tqdm import tqdm
 import numpy as np
 
-from proteinshake.utils import checkpoint, one_hot, compose_embeddings
+from proteinshake.utils import checkpoint, compose_embeddings, residue_one_hot
 
 
 class GraphDataset():
@@ -26,7 +26,7 @@ class GraphDataset():
 
     """
 
-    def __init__(self, root, proteins, embedding=one_hot, eps=None, k=None, weighted_edges=False):
+    def __init__(self, root, proteins, embedding=residue_one_hot, eps=None, k=None, weighted_edges=False):
         assert not (eps is None and k is None), 'You must specify eps or k in the graph construction.'
         self.construction = 'knn' if not k is None else 'eps'
         self.root = root
@@ -82,6 +82,7 @@ class GraphDataset():
 
         def graph2pyg(graph, info={}):
             nodes = torch.Tensor(graph[0]).float()
+            print(nodes.shape)
             edges = from_scipy_sparse_matrix(graph[1])
             return Data(x=nodes, edge_index=edges[0].long(), edge_attr=edges[1].unsqueeze(1).float(), **info2pyg(info))
         data_list = [graph2pyg(p, info=info) for p,info in zip(self.proteins,self.info)]

--- a/proteinshake/representations/point.py
+++ b/proteinshake/representations/point.py
@@ -1,6 +1,6 @@
 import os
 from tqdm import tqdm
-from proteinshake.utils import checkpoint, one_hot, compose_embeddings
+from proteinshake.utils import checkpoint, residue_one_hot, compose_embeddings
 
 class PointDataset():
     """ Point cloud representation of a protein structure dataset.
@@ -14,7 +14,7 @@ class PointDataset():
 
     """
 
-    def __init__(self, root, proteins, embedding=one_hot):
+    def __init__(self, root, proteins, embedding=residue_one_hot):
         self.root = root
         if type(embedding) == list:
             self.embedding = compose_embeddings(embedding)

--- a/proteinshake/representations/pyg_data.py
+++ b/proteinshake/representations/pyg_data.py
@@ -1,0 +1,16 @@
+import os
+import torch
+from torch_geometric.utils import from_scipy_sparse_matrix
+from torch_geometric.data import Data, InMemoryDataset
+
+class Dataset(InMemoryDataset):
+    def __init__(self, root, data_list, transform=None, pre_transform=None, pre_filter=None):
+        super().__init__(root, transform, pre_transform, pre_filter)
+        if not os.path.exists(root):
+            if self.pre_filter is not None:
+                data_list = [data for data in data_list if self.pre_filter(data)]
+            if self.pre_transform is not None:
+                data_list = [self.pre_transform(data) for data in data_list]
+            data, slices = self.collate(data_list)
+            torch.save((data, slices), root)
+        self.data, self.slices = torch.load(root)

--- a/proteinshake/utils/__init__.py
+++ b/proteinshake/utils/__init__.py
@@ -1,9 +1,10 @@
-from .embeddings import one_hot, tokenize, positional_encoding, compose_embeddings
+from .embeddings import residue_numeric, residue_one_hot, tokenize, positional_encoding, compose_embeddings
 from .pdbbind import *
 from .ppi import get_interfaces
 from .io import checkpoint, save, load, download_url, extract_tar, zip_file, unzip_file
 
-__all__ = ['one_hot',
+__all__ = ['residue_one_hot',
+           'residue_numeric',
            'tokenize',
            'positional_encoding',
            'compose_embeddings',

--- a/proteinshake/utils/embeddings.py
+++ b/proteinshake/utils/embeddings.py
@@ -8,7 +8,12 @@ import numpy as np
 
 alphabet = 'ARNDCEQGHILKMFPSTWYV'
 
-def one_hot(sequence):
+def residue_numeric(sequence):
+    """ Compute the index of the residue
+    """
+    return np.stack([alphabet.index(aa) for aa in sequence])
+
+def residue_one_hot(sequence):
     """ Compute the one-hot encoding of a protein sequence.
 
     Parameters


### PR DESCRIPTION
Moves dataset classes outside of `GraphDataset` class so that the dataset objects are not subclasses and they can be pickled by the dataloading workers.

Fixes Issue #57 