### PR TITLE
Add 1D embedding of residue identity

### DIFF
--- a/proteinshake/representations/graph.py
+++ b/proteinshake/representations/graph.py
@@ -3,7 +3,7 @@ from sklearn.neighbors import kneighbors_graph, radius_neighbors_graph
 from tqdm import tqdm
 import numpy as np
 
-from proteinshake.utils import checkpoint, compose_embeddings
+from proteinshake.utils import checkpoint, compose_embeddings, residue_one_hot
 
 
 class GraphDataset():
@@ -26,7 +26,7 @@ class GraphDataset():
 
     """
 
-    def __init__(self, root, proteins, embedding=None, eps=None, k=None, weighted_edges=False):
+    def __init__(self, root, proteins, embedding=residue_one_hot, eps=None, k=None, weighted_edges=False):
         assert not (eps is None and k is None), 'You must specify eps or k in the graph construction.'
         self.construction = 'knn' if not k is None else 'eps'
         self.root = root
@@ -47,10 +47,7 @@ class GraphDataset():
         self.proteins = self.convert(proteins)
 
     def protein2graph(self, protein):
-        if not self.embedding is None:
-            nodes = self.embedding(protein['sequence'])
-        else:
-            nodes = np.arange(len(protein['sequence']))
+        nodes = self.embedding(protein['sequence'])
         mode = 'distance' if self.weighted_edges else 'connectivity'
         if self.construction == 'eps':
             adj = radius_neighbors_graph(protein['coords'], radius=self.eps, mode=mode)

--- a/proteinshake/representations/graph.py
+++ b/proteinshake/representations/graph.py
@@ -3,7 +3,7 @@ from sklearn.neighbors import kneighbors_graph, radius_neighbors_graph
 from tqdm import tqdm
 import numpy as np
 
-from proteinshake.utils import checkpoint, one_hot, compose_embeddings
+from proteinshake.utils import checkpoint, compose_embeddings
 
 
 class GraphDataset():
@@ -26,7 +26,7 @@ class GraphDataset():
 
     """
 
-    def __init__(self, root, proteins, embedding=one_hot, eps=None, k=None, weighted_edges=False):
+    def __init__(self, root, proteins, embedding=None, eps=None, k=None, weighted_edges=False):
         assert not (eps is None and k is None), 'You must specify eps or k in the graph construction.'
         self.construction = 'knn' if not k is None else 'eps'
         self.root = root
@@ -47,7 +47,10 @@ class GraphDataset():
         self.proteins = self.convert(proteins)
 
     def protein2graph(self, protein):
-        nodes = self.embedding(protein['sequence'])
+        if not self.embedding is None:
+            nodes = self.embedding(protein['sequence'])
+        else:
+            nodes = np.arange(len(protein['sequence']))
         mode = 'distance' if self.weighted_edges else 'connectivity'
         if self.construction == 'eps':
             adj = radius_neighbors_graph(protein['coords'], radius=self.eps, mode=mode)
@@ -81,6 +84,7 @@ class GraphDataset():
 
         def graph2pyg(graph, info={}):
             nodes = torch.Tensor(graph[0]).float()
+            print(nodes.shape)
             edges = from_scipy_sparse_matrix(graph[1])
             return Data(x=nodes, edge_index=edges[0].long(), edge_attr=edges[1].unsqueeze(1).float(), **info2pyg(info))
         data_list = [graph2pyg(p, info=info) for p,info in zip(self.proteins,self.info)]

--- a/proteinshake/representations/point.py
+++ b/proteinshake/representations/point.py
@@ -1,6 +1,6 @@
 import os
 from tqdm import tqdm
-from proteinshake.utils import checkpoint, one_hot, compose_embeddings
+from proteinshake.utils import checkpoint, residue_one_hot, compose_embeddings
 
 class PointDataset():
     """ Point cloud representation of a protein structure dataset.
@@ -14,7 +14,7 @@ class PointDataset():
 
     """
 
-    def __init__(self, root, proteins, embedding=one_hot):
+    def __init__(self, root, proteins, embedding=residue_one_hot):
         self.root = root
         if type(embedding) == list:
             self.embedding = compose_embeddings(embedding)

--- a/proteinshake/utils/__init__.py
+++ b/proteinshake/utils/__init__.py
@@ -1,9 +1,10 @@
-from .embeddings import one_hot, tokenize, positional_encoding, compose_embeddings
+from .embeddings import residue_numeric, residue_one_hot, tokenize, positional_encoding, compose_embeddings
 from .pdbbind import *
 from .ppi import get_interfaces
 from .io import checkpoint, save, load, download_url, extract_tar, zip_file, unzip_file
 
-__all__ = ['one_hot',
+__all__ = ['residue_one_hot',
+           'residue_numeric',
            'tokenize',
            'positional_encoding',
            'compose_embeddings',

--- a/proteinshake/utils/embeddings.py
+++ b/proteinshake/utils/embeddings.py
@@ -8,7 +8,12 @@ import numpy as np
 
 alphabet = 'ARNDCEQGHILKMFPSTWYV'
 
-def one_hot(sequence):
+def residue_numeric(sequence):
+    """ Compute the index of the residue
+    """
+    return np.stack([alphabet.index(aa) for aa in sequence])
+
+def residue_one_hot(sequence):
     """ Compute the one-hot encoding of a protein sequence.
 
     Parameters


### PR DESCRIPTION
Solves #58 

When converting to graph, pass the `utils.residue_numeric` embedding for a 1D tensor of the amino acid index.

```python
from proteinshake.datasets import AlphaFoldDataset
from proteinshake.utils import residue_numeric
from torch_geometric.loader import DataLoader

if __name__ == "__main__":
    with tempfile.TemporaryDirectory() as tmp:
        dset = AlphaFoldDataset(root=tmp,
                                organism='escherichia_coli',
                                ).to_graph(eps=8, embedding=residue_numeric).pyg()
        print(dset[0].x)
```