### PR TITLE
on disk pyg dataset

### DIFF
--- a/proteinshake/frameworks/pyg.py
+++ b/proteinshake/frameworks/pyg.py
@@ -1,8 +1,9 @@
 import os
+import os.path as osp
 from itertools import repeat
 import torch
 from torch_geometric.utils import from_scipy_sparse_matrix
-from torch_geometric.data import Data, InMemoryDataset
+from torch_geometric.data import Data, InMemoryDataset, Dataset
 from proteinshake.utils import fx2str
 from tqdm import tqdm
 
@@ -20,7 +21,80 @@ def info2pyg(info):
             pass
     return new_info
 
-class PygGraphDataset(InMemoryDataset):
+class PygGraphDatasetOnDisk(Dataset):
+    """ Dataset class for on-disk graph in pytorch-geometric.
+
+    Parameters
+    ----------
+    graphs: generator
+        A generator of graph objects from GraphDataset.
+    size: int
+        The size of the dataset.
+    path: str
+        Path to save the processed dataset.
+    transform: function
+        Compare torch_geometric.data.Dataset.
+    pre_transform: function
+        Compare torch_geometric.data.Dataset.
+    pre_filter: function
+        Compare torch_geometric.data.Dataset.
+    """
+    def __init__(self, graphs, size, path, transform=None, pre_transform=None, pre_filter=None,  **kwargs):
+        self.size = size
+        self.graphs = graphs
+        self.transforms_repr = fx2str(pre_transform)+fx2str(pre_filter)
+
+        super().__init__(path, transform, pre_transform, pre_filter)
+
+        if osp.exists(osp.join(self.processed_dir, "transforms.pt")):
+            original_repr = torch.load(osp.join(self.processed_dir, "transforms.pt"))
+            assert original_repr == self.transforms_repr, f'The transforms are not the same as when the dataset was created. If you want to change them, delete the file at {path}'
+
+
+    def len(self):
+        return self.size
+
+    @property
+    def raw_file_names(self):
+        return []
+    
+    @property
+    def raw_dir(self):
+        return self.root
+
+    @property
+    def processed_file_names(self):
+        return [f'data_{i}.pt' for i in range(len(self))]
+
+    def process(self):
+        print(f">>> processing data and storing on disk.")
+        data_list = (Data(
+                          x = torch.from_numpy(graph.nodes),
+                          edge_index = from_scipy_sparse_matrix(graph.adj)[0].long(),
+                          edge_attr = from_scipy_sparse_matrix(graph.adj)[1].unsqueeze(1).float(),
+                          **info2pyg(graph.protein['protein']),
+                          **info2pyg(graph.protein[graph.resolution])
+                          )
+                    for graph in tqdm(self.graphs, desc='Converting to graph', total=self.size)
+                    )
+        if self.pre_filter is not None:
+            data_list = (data for data in data_list if self.pre_filter(data))
+        if self.pre_transform is not None:
+            data_list = (self.pre_transform(data) for data in data_list)
+
+        torch.save(self.transforms_repr, osp.join(self.processed_dir, "transforms.pt"))
+        for i, g_pyg in enumerate(data_list):
+            torch.save(g_pyg, osp.join(self.processed_dir, f'data_{i}.pt'))
+
+    def get(self, idx):
+        if idx > len(self) - 1:
+            raise StopIteration
+        data = torch.load(osp.join(self.processed_dir, f'data_{idx}.pt'))
+        return data
+
+
+
+class PygGraphDatasetInMemory(InMemoryDataset):
     """ Dataset class for graph in pytorch-geometric.
 
     Parameters
@@ -38,18 +112,20 @@ class PygGraphDataset(InMemoryDataset):
     pre_filter: function
         Compare torch_geometric.data.Dataset.
     """
-    def __init__(self, graphs, size, path, transform=None, pre_transform=None, pre_filter=None):
+    def __init__(self, graphs, size, path, transform=None, pre_transform=None, pre_filter=None, **kwargs):
         super().__init__(None, transform, pre_transform, pre_filter)
         self.size = size
         transforms_repr = fx2str(pre_transform)+fx2str(pre_filter)
         if not os.path.exists(path):
             data_list = [Data(
-                x = torch.from_numpy(graph.nodes),
-                edge_index = from_scipy_sparse_matrix(graph.adj)[0].long(),
-                edge_attr = from_scipy_sparse_matrix(graph.adj)[1].unsqueeze(1).float(),
-                **info2pyg(graph.protein['protein']),
-                **info2pyg(graph.protein[graph.resolution])
-            ) for graph in tqdm(graphs, desc='Converting to graph', total=size)]
+                              x = torch.from_numpy(graph.nodes),
+                              edge_index = from_scipy_sparse_matrix(graph.adj)[0].long(),
+                              edge_attr = from_scipy_sparse_matrix(graph.adj)[1].unsqueeze(1).float(),
+                              **info2pyg(graph.protein['protein']),
+                              **info2pyg(graph.protein[graph.resolution])
+                              )
+                          for graph in tqdm(graphs, desc='Converting to graph', total=size)
+                        ]
             if self.pre_filter is not None:
                 data_list = [data for data in data_list if self.pre_filter(data)]
             if self.pre_transform is not None:
@@ -74,3 +150,10 @@ class PygGraphDataset(InMemoryDataset):
             else:
                 data[key] = [item[s] for s in range(slices[idx], slices[idx + 1])]
         return data
+
+class PygGraphDataset:
+    def __new__(self, graphs, size, path, in_memory=True, *args,  **kwargs):
+        if in_memory:
+            return PygGraphDatasetInMemory(graphs, size, path+'.pyg', *args, **kwargs)
+        print("going on disk")
+        return PygGraphDatasetOnDisk(graphs, size, path, *args, **kwargs)

--- a/proteinshake/representations/graph.py
+++ b/proteinshake/representations/graph.py
@@ -62,7 +62,7 @@ class GraphDataset():
 
     """
 
-    def __init__(self, proteins, size, path, resolution='residue', eps=None, k=None, weighted_edges=False):
+    def __init__(self, proteins, size, path, resolution='residue', eps=None, k=None, weighted_edges=False, root=None):
         assert not (eps is None and k is None), 'You must specify eps or k in the graph construction.'
         construction = 'knn' if not k is None else 'eps'
         param = k if construction == 'knn' else eps
@@ -72,6 +72,6 @@ class GraphDataset():
         self.size = size
         os.makedirs(os.path.dirname(self.path), exist_ok=True)
 
-    def pyg(self, *args, **kwargs):
+    def pyg(self, in_memory=True, *args, **kwargs):
         from proteinshake.frameworks.pyg import PygGraphDataset
-        return PygGraphDataset(self.graphs, self.size, self.path+'.pyg', *args, **kwargs)
+        return PygGraphDataset(self.graphs, self.size, self.path+'.pyg', in_memory=in_memory,  *args, **kwargs)

--- a/proteinshake/representations/graph.py
+++ b/proteinshake/representations/graph.py
@@ -62,7 +62,7 @@ class GraphDataset():
 
     """
 
-    def __init__(self, proteins, size, path, resolution='residue', eps=None, k=None, weighted_edges=False, root=None):
+    def __init__(self, proteins, size, path, resolution='residue', eps=None, k=None, weighted_edges=False):
         assert not (eps is None and k is None), 'You must specify eps or k in the graph construction.'
         construction = 'knn' if not k is None else 'eps'
         param = k if construction == 'knn' else eps


### PR DESCRIPTION
Somewhat major change to the PyGraphDataset interface. `.pyg()` has a new argument, `on_disk=False` by default which is the normal behaviour. When setting `on_disk` to `True` we switch from `InMemoryDataset` to `Dataset`.