### PR TITLE
add TMalign on all pairs in dataset class

### DIFF
--- a/proteinshake/datasets/dataset.py
+++ b/proteinshake/datasets/dataset.py
@@ -115,7 +115,6 @@ class Dataset():
         int
             The limit to be applied to the number of downloaded/parsed files.
         """
-        return 5
         return None
 
     def check_arguments_same_as_hosted(self):
@@ -415,7 +414,6 @@ class Dataset():
             dist[name1][name2] = (d[0], d[2])
             dist[name2][name1] = (d[0], d[2])
 
-        print(dist)
         save(dist, dump_path)
         return dist
 

--- a/proteinshake/datasets/tm_align.py
+++ b/proteinshake/datasets/tm_align.py
@@ -14,33 +14,13 @@ from joblib import Parallel, delayed
 from tqdm import tqdm
 
 from proteinshake.datasets import Dataset
-from proteinshake.utils import extract_tar, download_url, save, load, unzip_file
-
-
-def tmalign_wrapper(pdb1, pdb2):
-    """Compute TM score with TMalign between two PDB structures.
-    Parameters
-    ----------
-    pdb1: str
-        Path to PDB.
-    arg2 : str
-        Path to PDB.
-    Returns
-    -------
-    float
-        TM score from `pdb1` to `pdb2`
-    float
-        TM score from `pdb2` to `pdb1`
-    float
-        RMSD between structures
-    """
-    try:
-        out = subprocess.run(['TMalign','-outfmt','2', pdb1, pdb2], stdout=subprocess.PIPE).stdout.decode()
-        path1, path2, TM1, TM2, RMSD, ID1, ID2, IDali, L1, L2, Lali = out.split('\n')[1].split('\t')
-    except Exception as e:
-        print(e)
-        return -1.
-    return float(TM1), float(TM2), float(RMSD)
+from proteinshake.utils import (extract_tar,
+                                download_url,
+                                save,
+                                load,
+                                unzip_file,
+                                tmalign_wrapper
+                                )
 
 
 class TMAlignDataset(Dataset):

--- a/proteinshake/utils/__init__.py
+++ b/proteinshake/utils/__init__.py
@@ -3,6 +3,7 @@ from .pdbbind import *
 from .ppi import get_interfaces
 from .io import *
 from .transforms import *
+from .wrappers import tmalign_wrapper
 
 __all__ = ['onehot',
            'tokenize',
@@ -19,7 +20,8 @@ __all__ = ['onehot',
            'ProgressParallel',
            'write_avro',
            'Compose',
-           'protein_to_pdb'
+           'protein_to_pdb',
+           'tmalign_wrapper'
            ]
 
 classes = __all__

--- a/proteinshake/utils/wrappers.py
+++ b/proteinshake/utils/wrappers.py
@@ -1,0 +1,32 @@
+import shutil
+import subprocess
+
+def tmalign_wrapper(pdb1, pdb2):
+    """Compute TM score with TMalign between two PDB structures.
+    Parameters
+    ----------
+    pdb1: str
+        Path to PDB.
+    arg2 : str
+        Path to PDB.
+    Returns
+    -------
+    float
+        TM score from `pdb1` to `pdb2`
+    float
+        TM score from `pdb2` to `pdb1`
+    float
+        RMSD between structures
+    """
+    assert shutil.which('TMalign') is not None,\
+           "No TMalign installation found. Go here to install : https://zhanggroup.org/TM-align/TMalign.cpp"
+    try:
+        out = subprocess.run(['TMalign','-outfmt','2', pdb1, pdb2], stdout=subprocess.PIPE).stdout.decode()
+        path1, path2, TM1, TM2, RMSD, ID1, ID2, IDali, L1, L2, Lali = out.split('\n')[1].split('\t')
+    except Exception as e:
+        print(e)
+        return -1.
+    return float(TM1), float(TM2), float(RMSD)
+
+
+


### PR DESCRIPTION
New method to base dataset class that is activated by the constructor flag `all_pairs_distance`.

Example usage:

```python
from proteinshake.datasets import RCSBDataset

da = RCSBDataset(root="tmtest",
                 use_precomputed=False,
                 all_pairs_distance=True
                 )
```

Dumps a dictionary that stores the TMscore and RMSD for all pairs in the dataset to the path `{self.root}/{self.__class__.__name__}_tmalign.json`

The dictionary is keyed by PDBIDs. For each key, we store a tuple which is `(tm_score, RMSD)`.
