### PR TITLE
sequence and structure-based clustering

### DIFF
--- a/proteinshake/datasets/dataset.py
+++ b/proteinshake/datasets/dataset.py
@@ -62,7 +62,8 @@ class Dataset():
             n_jobs              = 1,
             minimum_length      = 10,
             exclude_ids         = [],
-            all_pairs_distance  = False
+            all_pairs_distance_struc  = False
+            all_pairs_distance_seq = False
             ):
         self.repository_url = f'https://sandbox.zenodo.org/record/{RELEASES[release]}/files'
         self.n_jobs = n_jobs
@@ -73,13 +74,14 @@ class Dataset():
         self.check_sequence = check_sequence
         self.release = release
         self.exclude_ids = exclude_ids
-        self.compute_all_pairs_distance = all_pairs_distance
         os.makedirs(f'{self.root}', exist_ok=True)
         if not use_precomputed:
             self.start_download()
             self.parse()
-            if all_pairs_distance:
-                self.compute_distances()
+            if all_pairs_distance_struc:
+                self.compute_struc_distances()
+            if all_pairs_distance_seq:
+                self.compute_seq_distances()
         else:
             self.check_arguments_same_as_hosted()
 
@@ -374,7 +376,10 @@ class Dataset():
                }
         return data
 
-    def compute_distances(self, n_jobs=1):
+    def compute_seq_distances(self, n_jobs=1):
+        pass
+
+    def compute_struc_distances(self, n_jobs=1):
         """ Launch TMalign on all pairs of proteins in dataset.
         Saves TMalign output to `self.root/{Dataset.__class__}_tmalign.json.gz`
         Returns

--- a/proteinshake/datasets/dataset.py
+++ b/proteinshake/datasets/dataset.py
@@ -128,7 +128,6 @@ class Dataset():
         int
             The limit to be applied to the number of downloaded/parsed files.
         """
-        return 10
         return None
 
     def check_arguments_same_as_hosted(self):

--- a/proteinshake/tasks/task.py
+++ b/proteinshake/tasks/task.py
@@ -2,8 +2,13 @@ import os
 import os.path as osp
 import json
 from pathlib import Path
+from joblib import Parallel, delayed
 
+import numpy as np
 from sklearn.model_selection import train_test_split
+from sklearn.cluster import AgglomerativeClustering
+
+from proteinshake.utils import tmalign_wrapper, cdhit_wrapper
 
 class ShakeTask:
     """ Base class for task-related utilities.
@@ -98,6 +103,69 @@ class ShakeTask:
         self.train_ind = train
         self.val_ind = val
         self.test_ind = test
+
+    def cluster(by='structure', distance_threshold=0.3):
+        pass
+
+
+    def compute_clusters_struc(self, n_jobs=1):
+        """ Launch TMalign on all pairs of proteins in dataset.
+        Saves TMalign output to `self.root/{Dataset.__class__}_tmalign.json.gz`
+        Returns
+        -------
+        dict
+            TM score between all pairs of proteins as a dictionary.
+        dict
+            RMSD between all pairs of proteins as a dictionary.
+        """
+        from sklearn.cluster import AgglomerativeClustering
+        dump_name = f'{self.__class__.__name__}_tmalign.json'
+        dump_path = os.path.join(self.root, dump_name)
+        if os.path.exists(dump_path):
+            return load(dump_path)
+        elif self.use_precomputed:
+            download_url(os.path.join(self.repository_url, dump_name), self.root)
+            print('Unzipping...')
+            unzip_file(os.path.join(self.root, dump_name + ".gz"))
+            return load(dump_path)
+        if self.n_jobs == 1:
+            print('Computing the TM scores with use_precompute = False is very slow. Consider increasing n_jobs.')
+
+        pdbs = self.get_raw_files()
+        pdbids = [os.path.basename(p).split('.')[0] for p in pdbs]
+        [unzip_file(p) for p in pdbs]
+        pdbs = [p.rstrip('.gz') for p in pdbs]
+        pairs = list(itertools.combinations(range(len(pdbs)), 2))
+        todo = [(pdbs[p1], pdbs[p2]) for p1, p2 in pairs]
+
+        output = Parallel(n_jobs=self.n_jobs)(
+            delayed(tmalign_wrapper)(*pair) for pair in tqdm(todo, desc='Computing TM Scores')
+        )
+
+        dist = defaultdict(lambda: {})
+        rmsd = defaultdict(lambda: {})
+        for (pdb1, pdb2), d in zip(todo, output):
+            name1 = os.path.basename(pdb1).split('.')[0]
+            name2 = os.path.basename(pdb2).split('.')[0]
+            # each value is a tuple (tm-core, RMSD)
+            dist[name1][name2] = (d[0], d[2])
+            dist[name2][name1] = (d[0], d[2])
+
+        DM = np.zeros(len(pdbs), len(pdbs))
+        for i in range(len(pdbs)):
+            for j in range(i, len(pdbs)):
+                DM[i][j] = 1 - max(dist[pdbids[i]][pdbids[j]],
+                             dist[pdbids[j][pdbids[i]]
+                             )
+
+        save(dist, dump_path)
+
+        DM += DM.T
+        clusterer = AgglomerativeClustering(n_clusters=None,
+                                            distance_threshold=self.distance_threshold
+                                            )
+        clusterer.fit(DM)
+        return clusterer.labels_
 
     def compute_token_map(self):
         """ Computes and sets a dictionary that maps discrete labels to integers for classification tasks."""

--- a/proteinshake/transforms/surface.py
+++ b/proteinshake/transforms/surface.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from proteinshake.transforms import ShakeTransform
 from proteinshake.utils import protein_to_pdb
+from proteinshake.utils import dms_wrapper
 
 AA_THREE_TO_ONE = {'ALA': 'A', 'CYS': 'C', 'ASP': 'D', 'GLU': 'E', 'PHE': 'F', 'GLY': 'G', 'HIS': 'H', 'ILE': 'I', 'LYS': 'K', 'LEU': 'L', 'MET': 'M', 'ASN': 'N', 'PRO': 'P', 'GLN': 'Q', 'ARG': 'R', 'SER': 'S', 'THR': 'T', 'VAL': 'V', 'TRP': 'W', 'TYR': 'Y'}
 
@@ -16,7 +17,7 @@ class SurfaceTransform(ShakeTransform):
         self.d = d
 
     def __call__(self, protein):
-        surf = self._compute_surface(protein)
+        surf = dms_wrapper(protein)
         mode = 'atom' if 'atom' in protein.keys() else 'residue'
         new_prot = dict()
         new_prot['protein'] = protein['protein']
@@ -57,75 +58,3 @@ class SurfaceTransform(ShakeTransform):
             new_data['atom_type'] = surface_df['atom_name'].tolist()
         
         return new_data
-
-    def _compute_surface(self, protein, d=0.2):
-        """ Call DMS to compute a surface for the PDB.
-
-        Usage: dms input_file [-a] [-d density] [-g file] [-i file] [-n] [-w radius] [-v] -o file
-        -a	use all atoms, not just amino acids
-        -d	change density of points
-        -g	send messages to file
-        -i	calculate only surface for specified atoms
-        -n	calculate normals for surface points
-        -w	change probe radius
-        -v	verbose
-        -o	specify output file name (required)
-
-        See: https://www.cgl.ucsf.edu/chimera/docs/UsersGuide/midas/dms1.html#ref
-        """
-        with tempfile.TemporaryDirectory() as tf:
-            pdb_path = os.path.join(tf, "in.pdb")
-            dest = os.path.join(tf, "out.surf")
-            protein_to_pdb(protein, pdb_path)
-            assert shutil.which('dms') is not None, "DMS executable not in PATH go here to install https://www.cgl.ucsf.edu/chimera/docs/UsersGuide/midas/dms1.html#ref."
-            cmd = ['dms', pdb_path, '-n', '-d', str(d), '-o', dest]
-            subprocess.run(cmd,
-                           stdout=subprocess.DEVNULL,
-                           stderr=subprocess.STDOUT
-                           )
-            return self._parse_dms(dest)
-
-    def _parse_dms(self, path):
-        """ Extract surface points and normal vectors for each
-        point.
-
-        Parameters
-        ------------
-        path:
-            Path to DMS output file.
-
-        Returns
-        --------
-        pd.DataFrame
-            DataFrame with one row for each surface atom.
-        """
-        names = ['residue_name',
-                 'residue_index',
-                 'atom_name',
-                 'x',
-                 'y',
-                 'z',
-                 'point_type',
-                 'area',
-                 'x_norm',
-                 'y_norm',
-                 'z_norm'
-                 ]
-        df = pd.read_csv(path,
-                         delim_whitespace=True,
-                         header=None,
-                         names=names
-                         )
-        df = df.dropna(axis=0)
-        return df
-
-if __name__ == "__main__":
-    from proteinshake.datasets import TMAlignDataset
-    from proteinshake.transforms import SurfaceTransform
-    import tempfile
-    with tempfile.TemporaryDirectory() as tf:
-        da = TMAlignDataset(root=tf)
-        da_surf = da.to_point(
-                              resolution='atom',
-                              transform=SurfaceTransform()
-                              ).torch()

--- a/proteinshake/utils/__init__.py
+++ b/proteinshake/utils/__init__.py
@@ -4,6 +4,8 @@ from .ppi import get_interfaces
 from .io import *
 from .transforms import *
 from .wrappers import tmalign_wrapper
+from .wrappers import cdhit_wrapper
+from .wrappers import dms_wrapper
 
 __all__ = ['onehot',
            'tokenize',
@@ -21,7 +23,9 @@ __all__ = ['onehot',
            'write_avro',
            'Compose',
            'protein_to_pdb',
-           'tmalign_wrapper'
+           'tmalign_wrapper',
+           'cdhit_wrapper',
+           'dms_wrapper'
            ]
 
 classes = __all__

--- a/proteinshake/utils/io.py
+++ b/proteinshake/utils/io.py
@@ -56,7 +56,7 @@ def avro_schema_from_protein(protein):
         elif type(v).__name__ in typedict:
             return {'name':k, 'type': typedict[type(v).__name__]}
         else:
-            raise ValueError(f"All fields in a protein object need to be either int, float, bool or string, not {type(v).__name__}")
+            raise TypeError(f"All fields in a protein object need to be either int, float, bool or string, not {type(v).__name__}")
     schema = {
         'name': 'Protein',
         'namespace': 'Dataset',

--- a/proteinshake/utils/io.py
+++ b/proteinshake/utils/io.py
@@ -56,7 +56,7 @@ def avro_schema_from_protein(protein):
         elif type(v).__name__ in typedict:
             return {'name':k, 'type': typedict[type(v).__name__]}
         else:
-            raise f'All fields in a protein object need to be either int, float, bool or string, not {type(v).__name__}'
+            raise ValueError(f"All fields in a protein object need to be either int, float, bool or string, not {type(v).__name__}")
     schema = {
         'name': 'Protein',
         'namespace': 'Dataset',

--- a/proteinshake/utils/wrappers.py
+++ b/proteinshake/utils/wrappers.py
@@ -122,7 +122,7 @@ def _parse_dms(path):
     names = ['residue_name',
              'residue_index',
              'atom_name',
-             'x',
+    t        'x',
              'y',
              'z',
              'point_type',

--- a/proteinshake/utils/wrappers.py
+++ b/proteinshake/utils/wrappers.py
@@ -1,5 +1,9 @@
+import os.path as osp
+import tempfile
 import shutil
 import subprocess
+
+import pandas as pd
 
 def tmalign_wrapper(pdb1, pdb2):
     """Compute TM score with TMalign between two PDB structures.
@@ -29,4 +33,108 @@ def tmalign_wrapper(pdb1, pdb2):
     return float(TM1), float(TM2), float(RMSD)
 
 
+def cdhit_wrapper(sequences, sim_thresh=0.6):
+    """ Cluster sequences using CD-hit
 
+    Parameters
+    -----------
+    sequences: list
+        List of protein sequences to cluster.
+
+    Returns
+    --------
+    representatives: list
+        List of sequence indices to preserve as representatives.
+    """
+
+    assert shutil.which('cd-hit') is not None, "CD-HIT installation not found. Go here https://github.com/weizhongli/cdhit to install"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        in_file = osp.join(tmpdir, 'in.fasta')
+        out_file = osp.join(tmpdir, 'out.fasta')
+        with open(in_file, "w") as inp:
+            for i, s in enumerate(sequences):
+                inp.write(f"> {i} \n")
+                inp.write(s + "\n")
+
+        try:
+            cmd = ['cd-hit',
+                   '-c',
+                   str(sim_thresh),
+                   '-i',
+                   inp,
+                   '-o',
+                   out_file
+                  ]
+
+            subprocess.run(cmd)
+        except Exception as e:
+            print(e)
+            return -1
+        else:
+            with open(out_file, "r") as out:
+                inds = []
+                for line in out:
+                    inds.append(int(line.split()[-1]))
+            return inds
+
+def dms_wrapper(protein, d=0.2):
+    """ Call DMS to compute a surface for the PDB.
+
+    Usage: dms input_file [-a] [-d density] [-g file] [-i file] [-n] [-w radius] [-v] -o file
+    -a	use all atoms, not just amino acids
+    -d	change density of points
+    -g	send messages to file
+    -i	calculate only surface for specified atoms
+    -n	calculate normals for surface points
+    -w	change probe radius
+    -v	verbose
+    -o	specify output file name (required)
+
+    See: https://www.cgl.ucsf.edu/chimera/docs/UsersGuide/midas/dms1.html#ref
+    """
+    with tempfile.TemporaryDirectory() as tf:
+        pdb_path = os.path.join(tf, "in.pdb")
+        dest = os.path.join(tf, "out.surf")
+        protein_to_pdb(protein, pdb_path)
+        assert shutil.which('dms') is not None, "DMS executable not in PATH go here to install https://www.cgl.ucsf.edu/chimera/docs/UsersGuide/midas/dms1.html#ref."
+        cmd = ['dms', pdb_path, '-n', '-d', str(d), '-o', dest]
+        subprocess.run(cmd,
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.STDOUT
+                       )
+        return _parse_dms(dest)
+
+def _parse_dms(path):
+    """ Extract surface points and normal vectors for each
+    point.
+
+    Parameters
+    ------------
+    path:
+        Path to DMS output file.
+
+    Returns
+    --------
+    pd.DataFrame
+        DataFrame with one row for each surface atom.
+    """
+    names = ['residue_name',
+             'residue_index',
+             'atom_name',
+             'x',
+             'y',
+             'z',
+             'point_type',
+             'area',
+             'x_norm',
+             'y_norm',
+             'z_norm'
+             ]
+    df = pd.read_csv(path,
+                     delim_whitespace=True,
+                     header=None,
+                     names=names
+                     )
+    df = df.dropna(axis=0)
+    return df

--- a/proteinshake/utils/wrappers.py
+++ b/proteinshake/utils/wrappers.py
@@ -72,11 +72,15 @@ def cdhit_wrapper(sequences, sim_thresh=0.6):
             print(e)
             return -1
         else:
-            with open(out_file, "r") as out:
+            clusters = [0] * len(sequences)
+            with open(out_file + ".clstr", "r") as out:
                 inds = []
                 for line in out:
-                    inds.append(int(line.split()[-1]))
-            return inds
+                    if line.startswith(">)"):
+                        clust_id = int(line.split()[1])
+                    ind = int(line.split(">").split('.')[0])
+                    clusters[ind] = clust_id
+            return clusters
 
 def dms_wrapper(protein, d=0.2):
     """ Call DMS to compute a surface for the PDB.

--- a/proteinshake/utils/wrappers.py
+++ b/proteinshake/utils/wrappers.py
@@ -5,6 +5,8 @@ import subprocess
 
 import pandas as pd
 
+""" Wrappers for external programs. """
+
 def tmalign_wrapper(pdb1, pdb2):
     """Compute TM score with TMalign between two PDB structures.
     Parameters
@@ -62,12 +64,15 @@ def cdhit_wrapper(sequences, sim_thresh=0.6):
                    '-c',
                    str(sim_thresh),
                    '-i',
-                   inp,
+                   in_file,
                    '-o',
                    out_file
                   ]
 
-            subprocess.run(cmd)
+            subprocess.run(cmd,
+                           stdout=subprocess.DEVNULL,
+                           stderr=subprocess.STDOUT
+                          )
         except Exception as e:
             print(e)
             return -1
@@ -76,9 +81,10 @@ def cdhit_wrapper(sequences, sim_thresh=0.6):
             with open(out_file + ".clstr", "r") as out:
                 inds = []
                 for line in out:
-                    if line.startswith(">)"):
+                    if line.startswith(">"):
                         clust_id = int(line.split()[1])
-                    ind = int(line.split(">").split('.')[0])
+                        continue
+                    ind = int(line.split(">")[1].split('.')[0])
                     clusters[ind] = clust_id
             return clusters
 
@@ -126,7 +132,7 @@ def _parse_dms(path):
     names = ['residue_name',
              'residue_index',
              'atom_name',
-    t        'x',
+             'x',
              'y',
              'z',
              'point_type',


### PR DESCRIPTION
During dataset creation, we can optionally assign a cluster to each protein based on sequence and/or structure identity.

Sample usage:

```python
import tempfile
from proteinshake.datasets import RCSBDataset

with tempfile.TemporaryDirectory() as tmp:
    da = RCSBDataset(root=tmp,
                     use_precomputed=False,
                     cluster_sequence=True,
                     cluster_structure=True,
                     distance_threshold_sequence=0.3,
                     distance_threshold_structure=0.4
                     )
```               

Sequence clustering is done with [CD-hit](https://sites.google.com/view/cd-hit) and structure-based is done with TMalign. Both executables should be in PATH for this to work.

The result is a new protein-level attribute for each protein in the dataset such that the protein dictionary looks like this:

```python
{'ID': '4P79', 
'sequence': 'SEFSVAVETFGFFSALGLLLGLTLSNSYWRVSTNTIFENLWYSCATDSLGVSNCWDFPSLALSGYVQGCRALITAILLGFLGLFLGVGLRATNVGNDLSKKAKLLAIAGTLHILAGACGVAISWYAVNITTDFFNPLYAGTKYELGPALYLGWSASLLSILGGICVFSTAAAS',
'structure_cluster': 0, 
'sequence_cluster': 4}
```

Hence, similar sequences/proteins will be assigned to the same cluster, using the provided distance thresholds.

Structure-based clustering will be quite expensive to compute.

This information can be used directly or applied by the `ShakeTask` classes to create non-redundant splits.

This affects the base `Dataset` class so I wait for @timkucera 's approval before merging.

Fixed along the way:

* Type checking of protein dict has the f inside "" for f-string
* Did not raise any exception type, now raises TypeError 