### PR TITLE
allow multiple distance thresholds in clustering

### DIFF
--- a/proteinshake/utils/wrappers.py
+++ b/proteinshake/utils/wrappers.py
@@ -49,7 +49,8 @@ def cdhit_wrapper(sequences, sim_thresh=0.6):
         List of sequence indices to preserve as representatives.
     """
 
-    assert shutil.which('cd-hit') is not None, "CD-HIT installation not found. Go here https://github.com/weizhongli/cdhit to install"
+    assert shutil.which('cd-hit') is not None,\
+    "CD-HIT installation not found. Go here https://github.com/weizhongli/cdhit to install"
 
     with tempfile.TemporaryDirectory() as tmpdir:
         in_file = osp.join(tmpdir, 'in.fasta')


### PR DESCRIPTION
New option for computing clusters. Distance thresholds can be a single value or a list. If it is a list, a clustering is done for each threshold.

```python
import tempfile
from proteinshake.datasets import RCSBDataset

with tempfile.TemporaryDirectory() as tmp:
    da = RCSBDataset(root=tmp,
                     use_precomputed=False,
                     cluster_sequence=True,
                     cluster_structure=True,
                     distance_threshold_sequence=[0.3, 0.1],
                     distance_threshold_structure=[0.3, 0.1]
                     )

```

Protein dict looks like:

```
{'ID': '6GOX', 'sequence': 'RNDRTLRRMRKVVNIINAMEPEMEKLSDEELKGKTAEFRARLEKGEVLENLIPEAFAVVREASKRVFGMRHFDVQLLGGMVLNERCIAEMRTGEGKTLTATLPAYLNALTGKGVHVVTVNDYLAQRDAENNRPLFEFLGLTVGINLPGMPAPAKREAYAADITYGTNNEYGFDYLRDNMAFSPEERVQRKLHYALVDEVDSILIDEARTPLIISGPAEDSSEMYKRVNKIIPHLIRERGLVLIEELLVKEGGESLYSPANIMLMHHVTAALRAHALFTRDVDYIVKDGEVIWSDGLHQAVEAKEGVQIQNENQTLASITFQNYFRLYEKLAGMTGTADTEAFEFSSIYKLDTVVVPTNRPMIRKDLPDLVYMTEAEKIQAIIEDIKERTAKGQPVLVGTISIEKSELVSNELTKAGIKHNVLNAKFHANEAAIVAQAGYPAAVTIATNMAGRGTDIVLGGSWQAEVAALENPTAEQIEKIKADWQVRHDAVLEAGGLHIIGTERHESRRIDNQLRGRSGRQGDAGSSRFYLSMEDALMRIFASDRVSGMMRKLGMKPGEAIEHPWVTKAIANAQRKVESRNFDIRKQLLEYDDVANDQRRAIYSQRNELLDVSDVSETINSIREDVFKATIDAYIPPQSLEEMWDIPGLQERLKNDFDLDLPIAEWLDKEPELHEETLRERILAQSIEVYQRKEEVVGAEMMRHFEKGVMLQTLDSLWKEHLAAMDYLRQGIHLRGYAQKDPKQEYKRESFSMFAAMLESLKYEVISTLSKVQVRMP', 'structure_cluster_0.3': 7, 'structure_cluster_0.1': 7, 'sequence_cluster_0.3': 0, 'sequence_cluster_0.1': 0}
```

Note: removed the empty list keyword argument for `exclude_ids=[]`, replaced default value with `None`.