### PR TITLE
fix compatibility issues with pytorch2.0 and pyg

### DIFF
--- a/proteinshake/frameworks/dataset.py
+++ b/proteinshake/frameworks/dataset.py
@@ -66,3 +66,9 @@ class FrameworkDataset():
             return self.transform((data, protein_dict))
         else:
             return data, protein_dict
+
+    def len(self):
+        pass
+
+    def get(self):
+        pass


### PR DESCRIPTION
Fix the following error when upgrading to Pytorch 2.0:

```
TypeError: Can't instantiate abstract class PygGraphDataset with abstract methods get, len
```