### PR TITLE
PPI Task upgrade

### DIFF
--- a/proteinshake/datasets/dataset.py
+++ b/proteinshake/datasets/dataset.py
@@ -3,6 +3,7 @@
 Base dataset class for protein 3D structures.
 """
 import os, gzip, inspect, time, itertools, tarfile, io
+import copy
 from collections import defaultdict
 from functools import cached_property
 import multiprocessing as mp
@@ -288,14 +289,36 @@ class Dataset():
             if self.verbosity > 0: print('Unzipping...')
             unzip_file(f'{self.root}/{self.name}.{resolution}.avro.gz')
 
-    def chain_split(self, proteins):
-        """ Split proteins into individual chains """
-        new_proteins = []
-        for p in proteins:
-            for _, chain_df in p.groupby('chain_id'):
-                print(chain_df)
-                new_proteins.append(chain_df)
-        return new_proteins
+    def chain_split(self, protein):
+        """ Split protein into list of single chain dicts"""
+
+        def get_chain_inds(resolution):
+            chain_inds = {}
+            current_inds = set()
+
+            current_chain = protein[resolution]['chain_id'][0]
+
+            for i, chain_id in enumerate(protein[resolution]['chain_id']):
+                if chain_id != current_chain:
+                    chain_inds[current_chain] = current_inds
+                    current_chain = chain_id
+                    current_inds = set()
+                else:
+                    current_inds.add(i)
+                pass
+
+            return chain_inds
+
+        inds = {'residue': get_chain_inds('residue'), 'atom': get_chain_inds('atom')}
+
+        new_proteins = {chain: {'protein': {}, 'residue': {}, 'atom': {}} for chain in inds['residue'].keys()}
+        for chain, new_protein in new_proteins.items():
+            new_protein['protein'] = copy.deepcopy(protein['protein'])
+            for resolution in ['residue', 'atom']:
+                for k in protein[resolution].keys():
+                    new_protein[resolution][k] = [val for i, val in enumerate(protein[resolution][k]) if i in inds[resolution][chain]]
+
+        return list(new_proteins.values())
 
     def parse(self):
         """ Parses all PDB files returned from :meth:`proteinshake.datasets.Dataset.get_raw_files()` and saves them to disk. Can run in parallel.
@@ -303,7 +326,6 @@ class Dataset():
         if os.path.exists(f'{self.root}/{self.name}.residue.avro'):
             return
         # parse and filter
-        print("HIII")
         paths = self.get_raw_files()[:self.limit]
         proteins = Parallel(n_jobs=self.n_jobs)(delayed(self.parse_pdb)(path) for path in progressbar(paths, desc='Parsing', verbosity=self.verbosity))
         before = len(proteins)
@@ -312,7 +334,11 @@ class Dataset():
         if self.verbosity > 0: print(f'Filtered {before-len(proteins)} proteins.')
 
         if self.split_chains:
-            proteins = self.chain_split(proteins)
+            split_proteins = []
+            for p in proteins:
+                split_proteins.extend(self.chain_split(p))
+            proteins = split_proteins
+
         if self.verbosity > 0: print(f'Split by chain into {len(proteins)} separate items.')
 
         residue_proteins = [{'protein':p['protein'], 'residue':p['residue']} for p in proteins]

--- a/proteinshake/datasets/dataset.py
+++ b/proteinshake/datasets/dataset.py
@@ -211,7 +211,6 @@ class Dataset():
         int
             The limit to be applied to the number of downloaded/parsed files.
         """
-        return 20
         return None
 
     @property

--- a/proteinshake/datasets/dataset.py
+++ b/proteinshake/datasets/dataset.py
@@ -306,7 +306,6 @@ class Dataset():
 
         if self.verbosity > 0: print(f'Filtered {before-len(proteins)} proteins.')
 
-
         if self.center:
             print("Centering")
             proteins = [CenterTransform()(p) for p in proteins]
@@ -314,7 +313,6 @@ class Dataset():
             print("Rotating")
             seeds = (abs(hash(p['protein']['sequence'])) % 2**28 for p in proteins)
             proteins = [RandomRotateTransform(seed=seed)(p) for seed, p in zip(seeds, proteins)]
-
 
         residue_proteins = [{'protein':p['protein'], 'residue':p['residue']} for p in proteins]
         atom_proteins = [{'protein':p['protein'], 'atom':p['atom']} for p in proteins]
@@ -347,11 +345,15 @@ class Dataset():
         atom_sasa, residue_sasa, residue_rsa = [], [], []
         for i in atom_df['atom_number']:
             try:
+                assert not np.isnan(result.atomArea(i)), "nan sasa"
                 atom_sasa.append(result.atomArea(i))
             except:
                 atom_sasa.append(-1)
         for i,chain in zip(residue_df['residue_number'], residue_df['chain_id']):
             try:
+                assert not np.isnan(residue_result[chain][str(i)].total), "nan sasa"
+                assert not np.isnan(residue_result[chain][str(i)].relativeTotal), "nan sasa"
+
                 residue_sasa.append(residue_result[chain][str(i)].total)
                 residue_rsa.append(residue_result[chain][str(i)].relativeTotal)
             except:

--- a/proteinshake/datasets/dataset.py
+++ b/proteinshake/datasets/dataset.py
@@ -109,19 +109,17 @@ class Dataset():
             only_single_chain              = False,
             check_sequence                 = False,
             n_jobs                         = 1,
-            split_chains                   = False,
             minimum_length                 = 10,
             maximum_length                 = 2048,
             exclude_ids                    = [],
             verbosity                      = 2,
-            center                         = True,
-            random_rotate                  = True
+            # center                         = True, Put back after submission
+            # random_rotate                  = True
             ):
         self.repository_url = f'https://sandbox.zenodo.org/record/{RELEASES[release]}/files'
         self.n_jobs = n_jobs
-        self.split_chains = split_chains
-        self.random_rotate = random_rotate
-        self.center = center
+        # self.random_rotate = random_rotate
+        # self.center = center
         self.use_precomputed = use_precomputed
         self.root = root
         self.minimum_length = minimum_length
@@ -306,10 +304,12 @@ class Dataset():
 
         if self.verbosity > 0: print(f'Filtered {before-len(proteins)} proteins.')
 
-        if self.center:
+        # if self.center:
+        # if True:
+        # if self.random_rotate:
+        if self.name == 'ProteinProteinInteractionDataset':
             print("Centering")
             proteins = [CenterTransform()(p) for p in proteins]
-        if self.random_rotate:
             print("Rotating")
             seeds = (abs(hash(p['protein']['sequence'])) % 2**28 for p in proteins)
             proteins = [RandomRotateTransform(seed=seed)(p) for seed, p in zip(seeds, proteins)]

--- a/proteinshake/datasets/dataset.py
+++ b/proteinshake/datasets/dataset.py
@@ -321,7 +321,6 @@ class Dataset():
         for chain, new_protein in new_proteins.items():
             new_protein['protein'] = copy.deepcopy(protein['protein'])
             new_protein['protein']['sequence'] = "".join([protein['protein']['sequence'][i] for i in inds['residue'][chain]])
-            if protein['protein']['ID'] == '2xns':
             assert len(new_protein['protein']['sequence']) == counts[chain]
             for resolution in ['residue', 'atom']:
                 for k in protein[resolution].keys():

--- a/proteinshake/datasets/protein_protein_interface.py
+++ b/proteinshake/datasets/protein_protein_interface.py
@@ -79,7 +79,7 @@ class ProteinProteinInterfaceDataset(Dataset):
         self._interfaces = download_file(f'{self.name}.interfaces.json')
 
     def get_raw_files(self):
-        return glob.glob(f'{self.root}/raw/files/chains/*.pdb')[:self.limit]
+        return glob.glob(f'{self.root}/raw/files/chains/*.pdb')
 
     def get_id_from_filename(self, filename):
         return filename[:4]
@@ -156,9 +156,9 @@ class ProteinProteinInterfaceDataset(Dataset):
     def download(self):
         # download_url(f'https://pdbbind.oss-cn-hangzhou.aliyuncs.com/download/PDBbind_v{self.version}_PP.tar.gz', f'{self.root}/raw')
         # extract_tar(f'{self.root}/raw/PDBbind_v{self.version}_PP.tar.gz', f'{self.root}/raw/files', extract_members=True)
-        os.makedirs(f'{self.root}/raw/files/chains', exist_ok=True)
+        # os.makedirs(f'{self.root}/raw/files/chains', exist_ok=True)
         print("Chain splitting")
-        #self.chain_split(f'{self.root}/raw/files/chains')
+        self.chain_split(f'{self.root}/raw/files/chains')
 
     def chain_split(self, dest):
         """ Split all the raw PDBs in path to individual ones by chain.
@@ -171,6 +171,7 @@ class ProteinProteinInterfaceDataset(Dataset):
                 new_df = PandasPdb()
                 new_df._df = {'ATOM': chain_df}
                 new_df.to_pdb(os.path.join(dest, f"{pdbid}_{chain}.pdb"))
+                # assert not chain_df.isnull().values.any(), f"NULL in {p}"
         pass
 
     def get_id_from_filename(self, filename):

--- a/proteinshake/datasets/protein_protein_interface.py
+++ b/proteinshake/datasets/protein_protein_interface.py
@@ -60,10 +60,9 @@ class ProteinProteinInterfaceDataset(Dataset):
         'ProteinProteinInterfaceDataset.interfaces.json',
     ]
 
-    def __init__(self, cutoff=6, version='2020', split_chains=True, **kwargs):
+    def __init__(self, cutoff=6, version='2020', **kwargs):
         self.version = version
         self.cutoff = cutoff
-        kwargs['split_chains'] = split_chains
         super().__init__(**kwargs)
 
         def download_file(filename):

--- a/proteinshake/datasets/protein_protein_interface.py
+++ b/proteinshake/datasets/protein_protein_interface.py
@@ -16,7 +16,7 @@ class ProteinProteinInterfaceDataset(Dataset):
     """Protein-protein complexes from PDBBind with annotated interfaces. Residues
     and atoms in each protein are marked with a boolean `is_interface` to indicate
     residues/atoms defined to belong to the interface of two protein chains.
-    The default threshold for determining interface residues is 6 Angstroms.
+    The default threshold for determining interface residues is 6 Angstroms (used by DIPS).
     See :meth:`proteinshake.utils.get_interfaces` for details.
 
     Parameters
@@ -126,9 +126,6 @@ class ProteinProteinInterfaceDataset(Dataset):
                 current_chain = chain_id
             ind += 1
             seq_inds.append(ind)
-
-        # if protein['protein']['ID'] == '2xns':
-        print(protein['protein']['ID'], Counter(protein['residue']['chain_id']))
 
         query = kdt.query_radius(coords, cutoff)
         interface = []

--- a/proteinshake/tasks/protein_protein_interface.py
+++ b/proteinshake/tasks/protein_protein_interface.py
@@ -102,11 +102,6 @@ class ProteinProteinInterfaceTask(Task):
             result['auprc'][i] = metrics.average_precision_score(y, y_pred)
             result['sizes'][i] = len(y)
 
-        tot = np.sum(result['sizes'])
-        norm = result['sizes'] / tot
-        result['auroc'] *= norm
-        result['auprc'] *= norm
-
         return result
 
     def to_graph(self, *args, **kwargs):

--- a/proteinshake/tasks/protein_protein_interface.py
+++ b/proteinshake/tasks/protein_protein_interface.py
@@ -90,7 +90,7 @@ class ProteinProteinInterfaceTask(Task):
     def evaluate(self, y_true, y_pred):
         """ Evaluate performance of an interface classifier.
         """
-        result = {'auroc': np.zeros(len(y_true)),
+        raw_values = {'auroc': np.zeros(len(y_true)),
                   'auprc': np.zeros(len(y_true)),
                   'sizes':np.zeros(len(y_true))
                    }
@@ -98,9 +98,19 @@ class ProteinProteinInterfaceTask(Task):
         for i, (y, y_pred) in enumerate(zip(y_true, y_pred)):
             y = y.flatten()
             y_pred = y_pred.flatten()
-            result['auroc'][i] = metrics.roc_auc_score(y, y_pred)
-            result['auprc'][i] = metrics.average_precision_score(y, y_pred)
-            result['sizes'][i] = len(y)
+            raw_values['auroc'][i] = metrics.roc_auc_score(y, y_pred)
+            raw_values['auprc'][i] = metrics.average_precision_score(y, y_pred)
+            raw_values['sizes'][i] = len(y)
+
+        result = {}
+        tot = np.sum(raw_values['sizes'])
+        norm = raw_values['sizes'] / tot
+        result['auroc_weighted'] = np.mean(raw_values['auroc'] * norm)
+        result['auprc_weighted'] = np.mean(raw_values['auprc'] * norm)
+        result['auroc_median'] = np.median(raw_values['auroc'])
+        result['auprc_median'] = np.median(raw_values['auprc'])
+        result['auroc_mean'] = np.mean(raw_values['auroc'])
+        result['auprc_mean'] = np.mean(raw_values['auprc'])
 
         return result
 

--- a/proteinshake/tasks/protein_protein_interface.py
+++ b/proteinshake/tasks/protein_protein_interface.py
@@ -80,7 +80,7 @@ class ProteinProteinInterfaceTask(Task):
         contacts = np.zeros((chain_1_length, chain_2_length))
         inds = np.array(self.dataset._interfaces[pdbid][chain_1][chain_2])
         contacts[inds[:,0], inds[:,1]] = 1.0
-        return contacts
+        return np.array(contacts)
 
     @property
     def default_metric(self):

--- a/proteinshake/tasks/protein_protein_interface.py
+++ b/proteinshake/tasks/protein_protein_interface.py
@@ -52,8 +52,14 @@ class ProteinProteinInterfaceTask(Task):
         self.val_targets = [p for i in self.val_index for p in self.target(self.proteins[i])]
         self.test_targets = [p for i in self.test_index for p in self.target(self.proteins[i])]
 
-    def target(self, protein):
-        return protein['residue']['is_interface']
+    def target(self, protein_1, protein_2):
+        chain_1 = protein_1['residue']['chain_id'][0]
+        chain_2 = protein_2['residue']['chain_id'][0]
+
+        contacts = np.zeros((len(protein_1['protein']['sequence']), len(protein_2['protein']['sequence'])))
+        inds = self._interfaces[pdbid][chain_1][chain_2]
+        np.put(contacts, np.ravel_multi_index(np.transpose(inds), contacts.shape), 1)
+        return contacts
 
     @property
     def default_metric(self):

--- a/proteinshake/tasks/protein_protein_interface.py
+++ b/proteinshake/tasks/protein_protein_interface.py
@@ -3,7 +3,6 @@ from sklearn import metrics
 
 from proteinshake.datasets import ProteinProteinInterfaceDataset
 from proteinshake.tasks import Task
-from proteinshake.transforms import CenterTransform, RandomRotateTransform, Compose
 
 class ProteinProteinInterfaceTask(Task):
     """ Identify the binding residues of a protein-protein complex. This is a residue-level binary classification.
@@ -22,7 +21,7 @@ class ProteinProteinInterfaceTask(Task):
 
     @property
     def task_type(self):
-        return ('residue', 'binary')
+        return ('residue_pair', 'binary')
 
     @property
     def task_out(self):

--- a/proteinshake/tasks/task.py
+++ b/proteinshake/tasks/task.py
@@ -75,11 +75,14 @@ class Task:
 
     def compute_index(self):
         split_name = f'{self.split}_split_{self.split_similarity_threshold}' if self.split in ['sequence','structure'] else f'{self.split}_split'
+        print(self.proteins[0]['protein'])
         if split_name in self.proteins[0]['protein']:
+            print("reading splits")
             self.train_index = np.array([i for i,p in enumerate(self.proteins) if p['protein'][split_name] == 'train'])
             self.val_index = np.array([i for i,p in enumerate(self.proteins) if p['protein'][split_name] == 'val'])
             self.test_index = np.array([i for i,p in enumerate(self.proteins) if p['protein'][split_name] == 'test'])
         else:
+            print("computing splits")
             self.train_index, self.val_index, self.test_index = self.compute_custom_split(self.split)
 
         self.update_index()
@@ -89,13 +92,14 @@ class Task:
 
     def compute_targets(self):
         # compute targets (e.g. for scaling)
-        self.train_targets = np.array([self.target(self.proteins[i]) for i in self.train_index], dtype=object)
-        self.val_targets = np.array([self.target(self.proteins[i]) for i in self.val_index], dtype=object)
-        self.test_targets = np.array([self.target(self.proteins[i]) for i in self.test_index], dtype=object)
+        self.train_targets = [self.target(self.proteins[i]) for i in self.train_index]
+        self.val_targets = [self.target(self.proteins[i]) for i in self.val_index]
+        self.test_targets = [self.target(self.proteins[i]) for i in self.test_index]
             
     def compute_custom_split(self, split):
-        """ Implements custom splitting. Only necessary when not using the precomputed splits, e.g. when implementing a custom task.
+        """ Implements random splitting. Only necessary when not using the precomputed splits, e.g. when implementing a custom task.
         Note that the random, sequence and structure splits will be automatically computed for your custom task if it is merged into ProteinShake main.
+        Override this method to implement your own splitting logic.
         Compare also the proteinshake_release repository.
 
         Arguments
@@ -112,7 +116,11 @@ class Task:
         test_index
             Numpy array with the index of proteins in the test split.
         """
-        raise Exception('The requested split is not available. Implement <compute_custom_split> to provide your own splitting logic.')
+        inds = list(range(len(self.dataset.proteins())))
+        train, test = train_test_split(inds, test_size=0.2)
+        val, test = train_test_split(test, test_size=0.1)
+
+        return train, val, test
 
     @property
     def task_type(self):

--- a/proteinshake/tasks/task.py
+++ b/proteinshake/tasks/task.py
@@ -75,14 +75,11 @@ class Task:
 
     def compute_index(self):
         split_name = f'{self.split}_split_{self.split_similarity_threshold}' if self.split in ['sequence','structure'] else f'{self.split}_split'
-        print(self.proteins[0]['protein'])
         if split_name in self.proteins[0]['protein']:
-            print("reading splits")
             self.train_index = np.array([i for i,p in enumerate(self.proteins) if p['protein'][split_name] == 'train'])
             self.val_index = np.array([i for i,p in enumerate(self.proteins) if p['protein'][split_name] == 'val'])
             self.test_index = np.array([i for i,p in enumerate(self.proteins) if p['protein'][split_name] == 'test'])
         else:
-            print("computing splits")
             self.train_index, self.val_index, self.test_index = self.compute_custom_split(self.split)
 
         self.update_index()

--- a/proteinshake/transforms/coords.py
+++ b/proteinshake/transforms/coords.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.spatial.transform import Rotation
 
 from proteinshake.transforms import Transform
 
@@ -79,14 +80,10 @@ class RandomRotateTransform(Transform):
 
     def __call__(self, protein):
         coords = _get_coords_array(protein, resolution=self.resolution)
+        rotation = Rotation.random()
+        rotated_coordinates = rotation.apply(coords)
+        rotation_matrix = rotation.as_matrix()
 
-        # choose an angle and axis along which to rotate
-        rnd = int(np.random.randint(0,2+1,(1,)))
-        rot = int(np.random.randint(1,3+1,(1,)))
-        rotation_plane = {0:[0,1],1:[1,2],2:[0,2]}[rnd]
-        N = len(protein[self.resolution]['x'])
-        coords_rot = np.rot90(coords,k=rot, axes=rotation_plane).reshape(N, 3)
-
-        _set_coords(protein, coords_rot, resolution=self.resolution)
+        _set_coords(protein, rotated_coordinates, resolution=self.resolution)
 
         return protein

--- a/proteinshake/transforms/coords.py
+++ b/proteinshake/transforms/coords.py
@@ -29,7 +29,7 @@ def _get_coords_array(protein, resolution='residue'):
                      protein[resolution]['y'],
                      protein[resolution]['z']
                      ]
-                   ).T.reshape((N, 3, 1))
+                   ).T.reshape((N, 3))
 
 def _set_coords(protein, coord_array, resolution='residue', in_place=True):
     """ Given an Nx3 array of coordinates, set them to the
@@ -46,9 +46,9 @@ def _set_coords(protein, coord_array, resolution='residue', in_place=True):
 
     """
 
-    protein[resolution]['x'] = list(coord_array[:,0])
-    protein[resolution]['y'] = list(coord_array[:,1])
-    protein[resolution]['z'] = list(coord_array[:,2])
+    protein[resolution]['x'] = list(map(float,coord_array[:,0]))
+    protein[resolution]['y'] = list(map(float,coord_array[:,1]))
+    protein[resolution]['z'] = list(map(float,coord_array[:,2]))
 
 class CenterTransform(Transform):
     """ Center the coordinates of a protein at atom and residue level.

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -63,9 +63,9 @@ class TestTasks(unittest.TestCase):
 
     def test_protein_protein_interface(self):
         with tempfile.TemporaryDirectory() as tmp:
-            self.task_check(ProteinProteinInterfaceTask(split='random', root=tmp, verbosity=0))
-            self.task_check(ProteinProteinInterfaceTask(split='sequence', root=tmp, verbosity=0))
-            self.task_check(ProteinProteinInterfaceTask(split='structure', root=tmp, verbosity=0))
+            self.task_check(ProteinProteinInterfaceTask(split='random', root=tmp, verbosity=0), pair=True)
+            self.task_check(ProteinProteinInterfaceTask(split='sequence', root=tmp, verbosity=0), pair=True)
+            self.task_check(ProteinProteinInterfaceTask(split='structure', root=tmp,verbosity=0), pair=True)
 
     def test_structural_class(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
* New flags for the base `Dataset` class `random_rotate=True` and `center=True`. These are transforms applied by default to each protein that apply a random rotation and translate a protein to its center of mass. The random seed for the rotation is always `hash(protein['protein']['sequence']) % 2**28`
* New flag for base `Dataset` class, `split_chains=False`. When `True` each protein **chain** occupies a single item in the dataset. That is, if we had ['AB', 'C'] as proteins, when the chains are split we will have ['A', 'B', 'C'].
* PPI dataset uses all these flags as `True` when constructing.
* The `ProteinProteinInterfaceDataset` now has a new metadata `ProteinProteinInterfacedataset._interfaces` which is a dictionary storing inter-chain contacts as pairs of sequence indices. `_interfaces[<PDBID>][<chain_1>][<chain_2>] --> list[tuple]` where each tuple looks like `(index_chain_1, index_chain_2)` giving the position in the sequence of each pair of residue within 6 Anstroms and in different chains.
* The PPI task becomes a **pairwise** task so the `target()` method accepts two proteins and returns a binary matrix `C` of shape `N_residues_protein_1 x N_residues_protein_2` so that `C[i][j] --> 1` if residue `i` of `protein_1` is in contact with residue `j` of `protein_2` and 0 otherwise.